### PR TITLE
fix(minio): increase file size max threshold

### DIFF
--- a/tutorminio/plugin.py
+++ b/tutorminio/plugin.py
@@ -38,7 +38,7 @@ tutor_hooks.Filters.CONFIG_DEFAULTS.add_items(
         # upload below that threshold. But it also means that any file larger than the threshold will fail to upload
         # to GCS (including course export/import tar files). Increasing the threshold gives the ability to upload
         # larger files, but with the risk of timeouts, depending on the network speed.
-        ("MINIO_GCS_MULTIPART_THRESHOLD", 1024 * 1024 * 200),
+        ("MINIO_GCS_MULTIPART_THRESHOLD", 1024 * 1024 * 300),
     ]
 )
 


### PR DESCRIPTION
Description
-----------

- Increment the multiplier factor in the `MINIO_GCS_MULTIPART_THRESHOLD` to 300, so it becomes 300MB.

Motivation and Context
----------------------

It was reported recently that our staging was unable to export DTC-003 course. @melvinsoft Investigation shows the course has a compressed file size of 242MB, which is above the current 200MB setting.

The reported failure happened at the "Compress" stage, as can be seen in this Screenshot:

![Screenshot from 2023-12-20 13-07-22](https://github.com/correlation-one/tutor-minio/assets/3267469/d4fd7437-6137-4bcf-ae1a-73a810d687f0)

The exception reported in Sentry is the following:

```bash
ClientError: An error occurred (InternalError) when calling the CompleteMultipartUpload operation (reached max retries: 4): We encountered an internal error, please try again.: cause(gzip: invalid header)
```
The link to Sentry issue is [here](https://correlation-one.sentry.io/issues/4742295217/?environment=staging&project=4506225623040000&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=1)

Bare in mind, it will only last for 30 days because of Sentry's retention policy.

![Screenshot from 2023-12-20 13-46-39](https://github.com/correlation-one/tutor-minio/assets/3267469/5847146e-ff26-4c2a-a02e-2a9ce7a6fc93)
